### PR TITLE
chore: track videos via LFS and ignore env files; remove prisma .env …

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+apps/admin/public/videos/*.mp4 filter=lfs diff=lfs merge=lfs -text
+apps/customer/public/videos/*.mp4 filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ Thumbs.db
 *.swp
 .idea/
 .vscode/
+.env
+**/prisma/.env


### PR DESCRIPTION
…from indexTL;DR: Rewrote history to remove legacy secrets, replaced env values with placeholders, enabled Git LFS for large videos, and tightened ignores.

## What & Why
- Removed historical `.env` files (e.g. `apps/**/prisma/.env`) using `git filter-repo`.
- Replaced sensitive keys (Stripe/OpenAI/SendGrid/NEXTAUTH/THESMSWORKS) with placeholders.
- Removed legacy large video; enabled **Git LFS** for video assets.
- Updated `.gitignore` to cover `.env` and `**/prisma/.env`.

## Verification
- [x] `env.example` and Stripe docs contain placeholders only.
- [x] `.gitattributes` tracks:
  - `apps/admin/public/videos/*.mp4`
  - `apps/customer/public/videos/*.mp4`
- [x] GitHub → Code → Repository → LFS shows video assets tracked.
- [x] Security → Secret scanning shows no new findings on this branch.
- [x] CI workflow “Dependencies Install Only” runs successfully.

## Impact
- **History was rewritten**. Collaborators must re-clone or hard reset:
  ```bash
  git fetch --all --prune
  git switch main
  git reset --hard origin/main
